### PR TITLE
Update RTD to match repo name.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-icm20649/badge/?version=latest
-    :target: https://circuitpython.readthedocs.io/projects/icm20649/en/latest/
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-icm20x/badge/?version=latest
+    :target: https://circuitpython.readthedocs.io/projects/icm20x/en/latest/
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/discord/327254708534116352.svg


### PR DESCRIPTION
RTD project has been created and verified. 

Making this change because using an RTD link that does not contain the repo name triggers an Adabot check that uses the RTD URLs to verify inclusion of the lib in the driver list in the bundle.